### PR TITLE
Add spanish comments describing UMUL, SMUL and DIV

### DIFF
--- a/src/alu.sv
+++ b/src/alu.sv
@@ -13,10 +13,10 @@ module alu(
             4'b0001: Result = a - b;
             4'b0010: Result = a & b;
             4'b0011: Result = a | b;
-            4'b0100: Result = a * b;
-            4'b0101: Result = $signed(a) * $signed(b);
-            4'b0110: Result = a * b;
-            4'b0111: Result = b != 0 ? a / b : 32'hxxxxxxxx;
+            4'b0100: Result = a * b;                   // UMUL: multiplicación sin signo
+            4'b0101: Result = $signed(a) * $signed(b); // SMUL: multiplicación con signo
+            4'b0110: Result = a * b;                   // Reservado para extensiones
+            4'b0111: Result = b != 0 ? a / b : 32'hxxxxxxxx; // DIV: división protegida
             default: Result = 32'hxxxxxxxx;
         endcase
 

--- a/src/decode.sv
+++ b/src/decode.sv
@@ -42,10 +42,10 @@ module decode(
                                  Funct[4:1] == 4'b0010 ? 4'b0001 :
                                  Funct[4:1] == 4'b0000 ? 4'b0010 :
                                  Funct[4:1] == 4'b1100 ? 4'b0011 :
-                                 Funct[4:1] == 4'b0001 ? 4'b0100 :
-                                 Funct[4:1] == 4'b1000 ? 4'b0101 :
+                                 Funct[4:1] == 4'b0001 ? 4'b0100 : // UMUL
+                                 Funct[4:1] == 4'b1000 ? 4'b0101 : // SMUL
                                  Funct[4:1] == 4'b1001 ? 4'b0110 :
-                                 Funct[4:1] == 4'b1010 ? 4'b0111 :
+                                 Funct[4:1] == 4'b1010 ? 4'b0111 : // DIV
                                  4'bxxxx) : 4'b0000;
 
     assign FlagW[1] = ALUOp & Funct[0];

--- a/src/mainfsm.sv
+++ b/src/mainfsm.sv
@@ -29,8 +29,8 @@ module mainfsm(
                      ALUWB    = 8,
                      BRANCH   = 9,
                      UNKNOWN  = 10,
-                     DIV1     = 11,
-                     DIV2     = 12;
+                     DIV1     = 11, // Inicio de la división
+                     DIV2     = 12; // Fin de la división
 
     always @(posedge clk or posedge reset)
         if (reset)
@@ -46,7 +46,7 @@ module mainfsm(
                             if (Funct[5])
                                 nextstate = EXECUTEI;
                             else if (Funct[4:1] == 4'b1010)
-                                nextstate = DIV1;
+                                nextstate = DIV1; // Detecta la instrucción DIV
                             else
                                 nextstate = EXECUTER;
                         end
@@ -56,8 +56,8 @@ module mainfsm(
                        endcase
             EXECUTER: nextstate = ALUWB;
             EXECUTEI: nextstate = ALUWB;
-            DIV1:     nextstate = DIV2;
-            DIV2:     nextstate = ALUWB;
+            DIV1:     nextstate = DIV2; // Etapa 1 de DIV
+            DIV2:     nextstate = ALUWB; // Etapa 2 de DIV
             MEMADR:   nextstate = Funct[0] ? MEMRD : MEMWR;
             MEMRD:    nextstate = MEMWB;
             MEMWR:    nextstate = FETCH;
@@ -73,8 +73,8 @@ module mainfsm(
             DECODE:   controls = 13'b0000001001100;
             EXECUTER: controls = 13'b0000000000001;
             EXECUTEI: controls = 13'b0000000000101;
-            DIV1:     controls = 13'b0000000000001;
-            DIV2:     controls = 13'b0000000000001;
+            DIV1:     controls = 13'b0000000000001; // Señales para DIV paso 1
+            DIV2:     controls = 13'b0000000000001; // Señales para DIV paso 2
             ALUWB:    controls = 13'b0001000000000;
             MEMADR:   controls = 13'b0000000000100;
             MEMWR:    controls = 13'b0010010000000;


### PR DESCRIPTION
## Summary
- add inline Spanish comments for UMUL, SMUL and DIV operations in `alu.sv`
- document new ALU control encodings for UMUL, SMUL and DIV in `decode.sv`
- document DIV states in `mainfsm.sv`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686585bce754832caa41fce2ce32344b